### PR TITLE
[QWIK-002] Require cancellation notes, refetch listing screen

### DIFF
--- a/src/components/booking/BookingDetailsItem.tsx
+++ b/src/components/booking/BookingDetailsItem.tsx
@@ -28,7 +28,11 @@ export default component$<BookingDetailsItemProps>(
 
     const handleCancelBooking = $(async () => {
       await cancelBooking(id, notesEdited.value ?? "");
-      cancelledAt.value = Date.now().toString();
+
+      const now = new Date();
+      const isoDateString = now.toISOString();
+      cancelledAt.value = isoDateString;
+
       showCancelConfirmation.value = false;
     });
 
@@ -85,7 +89,7 @@ export default component$<BookingDetailsItemProps>(
                   bind:value={notesEdited}
                   class="w-full text-red-900 p-2"
                   type="textarea"
-                  placeholder="Reason for cancellation"
+                  placeholder="Reason for cancellation*"
                   value={notesEdited.value}
                 />
 
@@ -94,7 +98,12 @@ export default component$<BookingDetailsItemProps>(
                 </button>
 
                 <button
-                  class="bg-red-500 hover:bg-red-800"
+                  class={
+                    notesEdited.value?.length
+                      ? "bg-red-500 hover:bg-red-800"
+                      : "bg-slate-500 cursor-not-allowed"
+                  }
+                  disabled={!notesEdited.value?.length}
                   onClick$={handleCancelBooking}
                 >
                   Confirm Cancellation

--- a/src/routes/bookings/index.tsx
+++ b/src/routes/bookings/index.tsx
@@ -1,4 +1,4 @@
-import { Resource, component$ } from "@builder.io/qwik";
+import { Resource, component$, useResource$ } from "@builder.io/qwik";
 import type { Booking } from "~/services/bookingsService";
 import { fetchBookings } from "~/services/bookingsService";
 import BookingItem from "~/components/booking/BookingItem";
@@ -10,7 +10,9 @@ export const useBookingsLoader = routeLoader$(async () => {
 });
 
 export default component$(() => {
-  const bookingsData = useBookingsLoader();
+  const bookingsData = useResource$<Booking[]>(async () => {
+    return fetchBookings();
+  });
 
   return (
     <div class="p-8">


### PR DESCRIPTION
Why
--
As a user cancelling a booking, I should be required to add notes to avoid API errors
As a user who has cancelled a booking and is now viewing the listings, I should see the latest data

How
--
- Update BookingDetailsItem to render a standard ISO Date upon cancellation,
- Update BookingDetailsItem to disable submit cancel button until notes are populated
- Update Bookings page to fetch fresh data on pageload to avoid stale state rendering immediately after cancelling a booking